### PR TITLE
Change the queue for the dispatched jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ php artisan operations:make <operation_name> // create operation file
 php artisan operations:process                   // process operation files
 php artisan operations:process --sync            // force syncronously execution
 php artisan operations:process --async           // force asyncronously execution
-php artisan operations:process --queue=<name>    // change queue that the job will be dispatched to
+php artisan operations:process --queue=<name>    // force queue that the job will be dispatched to
 php artisan operations:process --test            // dont flag operations as processed
 php artisan operations:process <operation_name>  // re-run one specific operation
 ```
@@ -218,8 +218,6 @@ If something went wrong (or if you just feel like it), you can process an operat
 ```shell
 php artisan operations:process XXXX_XX_XX_XXXXXX_awesome_operation
 ```
-
-**Hint!** This does not restart the existing job in your queue. It dispatches another `OneTimeOperationProcessJob`!
 
 ### Testing the operation
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ php artisan operations:make <operation_name> // create operation file
 php artisan operations:process                   // process operation files
 php artisan operations:process --sync            // force syncronously execution
 php artisan operations:process --async           // force asyncronously execution
+php artisan operations:process --queue=<name>    // change queue that the job will be dispatched to
 php artisan operations:process --test            // dont flag operations as processed
 php artisan operations:process <operation_name>  // re-run one specific operation
 ```
@@ -130,6 +131,11 @@ return new class extends OneTimeOperation
      * Determine if the operation is being processed asyncronously.
      */
     protected bool $async = true;
+    
+    /**
+     * The queue that the job will be dispatched to.
+     */
+    protected string $queue = 'default';
 
     /**
      * Process the operation.
@@ -155,9 +161,12 @@ public function process(): void
 ```
 
 By default, the operation is being processed ***asyncronously*** (based on your configuration) by dispatching the job `OneTimeOperationProcessJob`. 
+By default, the operation is being dispatched to the `default` queue of your project. Change the `$queue` as you wish.  
 
 You can also execute the code syncronously by setting the `$async` flag to `false`. 
 _(this is only recommended for small operations, since the processing of these operations should be part of the deployment process)_
+
+**Hint:** If you use syncronous processing, the `$queue` attribute will be ignored. 
 
 ### Processing the operations
 
@@ -192,6 +201,14 @@ php artisan operations:process --sync   // force dispatchSync()
 **Hint!** If `operation:process` is part of your deployment process, it is **not recommended** to process the operations syncronously, 
 since an error in your operation could make your whole deployment fail. 
 
+### Force different queue for all operations 
+
+You can ignore the `$queue` attribute of all operation files by providing the `--queue` option in the artisan call:  
+
+```shell
+php artisan operations:process --queue=redis  // force redis queue 
+```
+
 ### Re-run an operation
 
 ![One-Time Operations for Laravel - Re-run an operation manually](https://user-images.githubusercontent.com/65356688/224440344-3d095730-12c3-4a2c-b4c3-42a8b6d60767.png)
@@ -201,6 +218,8 @@ If something went wrong (or if you just feel like it), you can process an operat
 ```shell
 php artisan operations:process XXXX_XX_XX_XXXXXX_awesome_operation
 ```
+
+**Hint!** This does not restart the existing job in your queue. It dispatches another `OneTimeOperationProcessJob`!
 
 ### Testing the operation
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ php artisan operations:make <operation_name> // create operation file
 php artisan operations:process                   // process operation files
 php artisan operations:process --sync            // force syncronously execution
 php artisan operations:process --async           // force asyncronously execution
-php artisan operations:process --queue=<name>    // force queue that the job will be dispatched to
+php artisan operations:process --queue=<name>    // force queue, that the job will be dispatched to
 php artisan operations:process --test            // dont flag operations as processed
 php artisan operations:process <operation_name>  // re-run one specific operation
 ```
@@ -166,7 +166,7 @@ By default, the operation is being dispatched to the `default` queue of your pro
 You can also execute the code syncronously by setting the `$async` flag to `false`. 
 _(this is only recommended for small operations, since the processing of these operations should be part of the deployment process)_
 
-**Hint:** If you use syncronous processing, the `$queue` attribute will be ignored. 
+**Hint:** If you use syncronous processing, the `$queue` attribute will be ignored (duh!). 
 
 ### Processing the operations
 
@@ -203,7 +203,7 @@ since an error in your operation could make your whole deployment fail.
 
 ### Force different queue for all operations 
 
-You can ignore the `$queue` attribute of all operation files by providing the `--queue` option in the artisan call:  
+You can provide the `--queue` option in the artisan call. The given queue will be used for all operations, ignoring the `$queue` attribute in the class.  
 
 ```shell
 php artisan operations:process --queue=redis  // force redis queue 

--- a/src/Commands/OneTimeOperationsProcessCommand.php
+++ b/src/Commands/OneTimeOperationsProcessCommand.php
@@ -14,7 +14,7 @@ class OneTimeOperationsProcessCommand extends OneTimeOperationsCommand
                             {--test : Process operation without tagging it as processed, so you can call it again}
                             {--async : Ignore setting in operation and process all operations asynchronously}
                             {--sync : Ignore setting in operation and process all operations synchronously}
-                            {--queue= : Set the queue that all jobs will be dispatched to}';
+                            {--queue= : Set the queue, that all jobs will be dispatched to}';
 
     protected $description = 'Process all unprocessed one-time operations';
 

--- a/src/OneTimeOperation.php
+++ b/src/OneTimeOperation.php
@@ -10,6 +10,11 @@ abstract class OneTimeOperation
     protected bool $async = true;
 
     /**
+     * The queue that the job will be dispatched to.
+     */
+    protected string $queue = 'default';
+
+    /**
      * Process the operation.
      */
     abstract public function process(): void;
@@ -17,5 +22,10 @@ abstract class OneTimeOperation
     public function isAsync(): bool
     {
         return $this->async;
+    }
+
+    public function getQueue(): string
+    {
+        return $this->queue;
     }
 }

--- a/stubs/one-time-operation.stub
+++ b/stubs/one-time-operation.stub
@@ -10,6 +10,11 @@ return new class extends OneTimeOperation
     protected bool $async = true;
 
     /**
+     * The queue that the job will be dispatched to.
+     */
+    protected string $queue = 'default';
+
+    /**
      * Process the operation.
      */
     public function process(): void


### PR DESCRIPTION
Provide a $queue attribute in an OneTimeOperation class to change the queue, that the job will be dispatched to.

Provide the --queue option with the artisan operations:process command to force a specific queue for all operations