### PR TITLE
feat(isolated): add isolation run when we deploy in multiple instance…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .phpunit.result.cache
+vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ php artisan operations:process                   // process all new operation fi
 php artisan operations:process --sync            // force syncronously execution
 php artisan operations:process --async           // force asyncronously execution
 php artisan operations:process --test            // dont flag operations as processed
+php artisan operations:process --isolated        // Do not run the command if another instance of the command is already running
+
 
 php artisan operations:process --queue=<name>    // force queue, that the job will be dispatched to
 php artisan operations:process --tag=<tagname>   // only process operations, that have the given tag

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ php artisan operations:process --async           // force asyncronously executio
 php artisan operations:process --test            // dont flag operations as processed
 php artisan operations:process --isolated        // Do not run the command if another instance of the command is already running
 
-
 php artisan operations:process --queue=<name>    // force queue, that the job will be dispatched to
 php artisan operations:process --tag=<tagname>   // only process operations, that have the given tag
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "homepage": "https://github.com/timokoerber/laravel-one-time-operations",
     "require": {
         "php": "^8.0",
+        "illuminate/contracts": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2fac101751c9c61169861cb24a165a46",
+    "content-hash": "64d3fcf4cbca866987c187590cce3ea0",
     "packages": [
         {
             "name": "brick/math",
@@ -846,72 +846,6 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2023-02-22T14:38:06+00:00"
-        },
-        {
-            "name": "laravel/pint",
-            "version": "v1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/pint.git",
-                "reference": "e48e3fadd7863d6b7d03464f5c4f211a828b890f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/e48e3fadd7863d6b7d03464f5c4f211a828b890f",
-                "reference": "e48e3fadd7863d6b7d03464f5c4f211a828b890f",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "ext-tokenizer": "*",
-                "ext-xml": "*",
-                "php": "^8.1.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.14.4",
-                "illuminate/view": "^10.0.0",
-                "laravel-zero/framework": "^10.0.0",
-                "mockery/mockery": "^1.5.1",
-                "nunomaduro/larastan": "^2.4.0",
-                "nunomaduro/termwind": "^1.15.1",
-                "pestphp/pest": "^1.22.4"
-            },
-            "bin": [
-                "builds/pint"
-            ],
-            "type": "project",
-            "autoload": {
-                "psr-4": {
-                    "App\\": "app/",
-                    "Database\\Seeders\\": "database/seeders/",
-                    "Database\\Factories\\": "database/factories/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "An opinionated code formatter for PHP.",
-            "homepage": "https://laravel.com",
-            "keywords": [
-                "format",
-                "formatter",
-                "lint",
-                "linter",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/laravel/pint/issues",
-                "source": "https://github.com/laravel/pint"
-            },
-            "time": "2023-02-21T15:44:57+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/src/Commands/OneTimeOperationsProcessCommand.php
+++ b/src/Commands/OneTimeOperationsProcessCommand.php
@@ -2,6 +2,7 @@
 
 namespace TimoKoerber\LaravelOneTimeOperations\Commands;
 
+use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use TimoKoerber\LaravelOneTimeOperations\Jobs\OneTimeOperationProcessJob;
@@ -9,7 +10,7 @@ use TimoKoerber\LaravelOneTimeOperations\Models\Operation;
 use TimoKoerber\LaravelOneTimeOperations\OneTimeOperationFile;
 use TimoKoerber\LaravelOneTimeOperations\OneTimeOperationManager;
 
-class OneTimeOperationsProcessCommand extends OneTimeOperationsCommand
+class OneTimeOperationsProcessCommand extends OneTimeOperationsCommand implements Isolatable
 {
     protected $signature = 'operations:process
                             {name? : Name of specific operation}


### PR DESCRIPTION
Assuming you have infrastructure with multiple server application, for example with kubernetes, if you deploy at once in all servers, you will face race condition where processing is started multiple time.

For that case, Laravel core team introduce `isolated` flag for any command which implement `Illuminate\Contracts\Console\Isolatable`. 

My Pull request add this feature to `operations:process` 


**Migration documentation**

https://laravel.com/docs/9.x/migrations#main-content section `Isolating Migration Execution`

**To dig more**

here it is use on Migrate command
https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Console/Migrations/MigrateCommand.php#L6

And consume on Command runner
https://github.com/laravel/framework/blob/9.x/src/Illuminate/Console/Command.php#L169