### PR TITLE
Publish migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .phpunit.result.cache
+
+/.idea
+/vendor

--- a/database/migrations/2023_02_28_000000_create_one_time_operations_table.php
+++ b/database/migrations/2023_02_28_000000_create_one_time_operations_table.php
@@ -6,18 +6,10 @@ use Illuminate\Support\Facades\Schema;
 use TimoKoerber\LaravelOneTimeOperations\Models\Operation;
 use TimoKoerber\LaravelOneTimeOperations\OneTimeOperationManager;
 
-class CreateOneTimeOperationsTable extends Migration
-{
-    protected string $name;
-
-    public function __construct()
-    {
-        $this->name = OneTimeOperationManager::getTableName();
-    }
-
+return new class () extends Migration {
     public function up()
     {
-        Schema::create($this->name, function (Blueprint $table) {
+        Schema::create(OneTimeOperationManager::getTableName(), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name');
             $table->enum('dispatched', [Operation::DISPATCHED_SYNC, Operation::DISPATCHED_ASYNC]);
@@ -27,6 +19,6 @@ class CreateOneTimeOperationsTable extends Migration
 
     public function down()
     {
-        Schema::dropIfExists($this->name);
+        Schema::dropIfExists(OneTimeOperationManager::getTableName());
     }
 }

--- a/database/migrations/2023_02_28_000000_create_one_time_operations_table.php
+++ b/database/migrations/2023_02_28_000000_create_one_time_operations_table.php
@@ -21,4 +21,4 @@ return new class () extends Migration {
     {
         Schema::dropIfExists(OneTimeOperationManager::getTableName());
     }
-}
+};

--- a/src/Providers/OneTimeOperationsServiceProvider.php
+++ b/src/Providers/OneTimeOperationsServiceProvider.php
@@ -43,11 +43,11 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
     protected function migrationFileExists(): bool
     {
         $files = $this->app->make(Filesystem::class)->glob(sprintf(
-           '%s%s%s',
-           database_path('migrations'),
-           DIRECTORY_SEPARATOR,
-           '*_create_one_time_operations_table.php'
-       ));
+            '%s%s%s',
+            database_path('migrations'),
+            DIRECTORY_SEPARATOR,
+            '*_create_one_time_operations_table.php'
+        ));
 
         return count($files) > 0;
     }

--- a/src/Providers/OneTimeOperationsServiceProvider.php
+++ b/src/Providers/OneTimeOperationsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace TimoKoerber\LaravelOneTimeOperations\Providers;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use TimoKoerber\LaravelOneTimeOperations\Commands\OneTimeOperationShowCommand;
 use TimoKoerber\LaravelOneTimeOperations\Commands\OneTimeOperationsMakeCommand;
@@ -11,8 +12,6 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        $this->loadMigrationsFrom([__DIR__.'/../../database/migrations']);
-
         if ($this->app->runningInConsole()) {
             $this->commands(OneTimeOperationsMakeCommand::class);
             $this->commands(OneTimeOperationsProcessCommand::class);
@@ -21,6 +20,14 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
             $this->publishes([
                  __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
              ], 'one-time-operations-config');
+
+            $this->publishes([
+                 __DIR__.'/../../database/migrations/2023_02_28_000000_create_one_time_operations_table.php' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_one_time_operations_table.php'),
+             ], 'one-time-operations-migrations');
+
+            if (! $this->migrationFileExists()) {
+                $this->loadMigrationsFrom([__DIR__.'/../../database/migrations']);
+            }
         }
     }
 
@@ -29,5 +36,17 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/../../config/one-time-operations.php', 'one-time-operations'
         );
+    }
+
+    protected function migrationFileExists(): bool
+    {
+        $files = $this->app->make(Filesystem::class)->glob(sprintf(
+           '%s%s%s',
+           database_path('migrations'),
+           DIRECTORY_SEPARATOR,
+           '*_create_one_time_operations_table.php'
+       ));
+
+        return count($files) > 0;
     }
 }

--- a/src/Providers/OneTimeOperationsServiceProvider.php
+++ b/src/Providers/OneTimeOperationsServiceProvider.php
@@ -13,14 +13,14 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
     {
         $this->loadMigrationsFrom([__DIR__.'/../../database/migrations']);
 
-        $this->publishes([
-            __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
-        ]);
-
         if ($this->app->runningInConsole()) {
             $this->commands(OneTimeOperationsMakeCommand::class);
             $this->commands(OneTimeOperationsProcessCommand::class);
             $this->commands(OneTimeOperationShowCommand::class);
+
+            $this->publishes([
+                 __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
+             ]);
         }
     }
 

--- a/src/Providers/OneTimeOperationsServiceProvider.php
+++ b/src/Providers/OneTimeOperationsServiceProvider.php
@@ -13,21 +13,23 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
-            $this->commands(OneTimeOperationsMakeCommand::class);
-            $this->commands(OneTimeOperationsProcessCommand::class);
-            $this->commands(OneTimeOperationShowCommand::class);
+            return;
+        }
+            
+        $this->commands(OneTimeOperationsMakeCommand::class);
+        $this->commands(OneTimeOperationsProcessCommand::class);
+        $this->commands(OneTimeOperationShowCommand::class);
 
-            $this->publishes([
-                 __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
-             ], 'one-time-operations-config');
+        $this->publishes([
+             __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
+         ], 'one-time-operations-config');
 
-            $this->publishes([
-                 __DIR__.'/../../database/migrations/2023_02_28_000000_create_one_time_operations_table.php' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_one_time_operations_table.php'),
-             ], 'one-time-operations-migrations');
+        $this->publishes([
+             __DIR__.'/../../database/migrations/2023_02_28_000000_create_one_time_operations_table.php' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_one_time_operations_table.php'),
+         ], 'one-time-operations-migrations');
 
-            if (! $this->migrationFileExists()) {
-                $this->loadMigrationsFrom([__DIR__.'/../../database/migrations']);
-            }
+        if (! $this->migrationFileExists()) {
+            $this->loadMigrationsFrom([__DIR__.'/../../database/migrations']);
         }
     }
 

--- a/src/Providers/OneTimeOperationsServiceProvider.php
+++ b/src/Providers/OneTimeOperationsServiceProvider.php
@@ -12,7 +12,7 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        if ($this->app->runningInConsole()) {
+        if (! $this->app->runningInConsole()) {
             return;
         }
             

--- a/src/Providers/OneTimeOperationsServiceProvider.php
+++ b/src/Providers/OneTimeOperationsServiceProvider.php
@@ -15,18 +15,18 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
         if (! $this->app->runningInConsole()) {
             return;
         }
-            
+
         $this->commands(OneTimeOperationsMakeCommand::class);
         $this->commands(OneTimeOperationsProcessCommand::class);
         $this->commands(OneTimeOperationShowCommand::class);
 
         $this->publishes([
-             __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
-         ], 'one-time-operations-config');
+            __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
+        ], 'one-time-operations-config');
 
         $this->publishes([
-             __DIR__.'/../../database/migrations/2023_02_28_000000_create_one_time_operations_table.php' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_one_time_operations_table.php'),
-         ], 'one-time-operations-migrations');
+            __DIR__.'/../../database/migrations/2023_02_28_000000_create_one_time_operations_table.php' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_one_time_operations_table.php'),
+        ], 'one-time-operations-migrations');
 
         if (! $this->migrationFileExists()) {
             $this->loadMigrationsFrom([__DIR__.'/../../database/migrations']);

--- a/src/Providers/OneTimeOperationsServiceProvider.php
+++ b/src/Providers/OneTimeOperationsServiceProvider.php
@@ -20,7 +20,7 @@ class OneTimeOperationsServiceProvider extends ServiceProvider
 
             $this->publishes([
                  __DIR__.'/../../config/one-time-operations.php' => config_path('one-time-operations.php'),
-             ]);
+             ], 'one-time-operations-config');
         }
     }
 


### PR DESCRIPTION
This PR adds the ability to publish the migration file.

This is a breaking change, so I check if the migration file exists before loading the migrations if it is accepted, in a future major release the `loadMigrationsFrom` can be removed.