### PR TITLE
`operantions:make` command to return real path of the newly create file

### DIFF
--- a/src/Commands/OneTimeOperationsMakeCommand.php
+++ b/src/Commands/OneTimeOperationsMakeCommand.php
@@ -17,7 +17,7 @@ class OneTimeOperationsMakeCommand extends OneTimeOperationsCommand
     {
         try {
             $file = OneTimeOperationCreator::createOperationFile($this->argument('name'), $this->option('essential'));
-            $this->components->info(sprintf('One-time operation [%s] created successfully.', $file->getOperationName()));
+            $this->components->info(sprintf('One-time operation [%s] created successfully.', $file->getOperationFilePath()));
 
             return self::SUCCESS;
         } catch (Throwable $e) {

--- a/src/OneTimeOperationFile.php
+++ b/src/OneTimeOperationFile.php
@@ -31,6 +31,11 @@ class OneTimeOperationFile
         return Str::remove('.php', $filename);
     }
 
+    public function getOperationFilePath(): string
+    {
+        return $this->file->getRealPath();
+    }
+
     public function getClassObject(): OneTimeOperation
     {
         if (! $this->classObject) {

--- a/tests/Feature/OneTimeOperationCommandTest.php
+++ b/tests/Feature/OneTimeOperationCommandTest.php
@@ -21,7 +21,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         // create operation file
         $this->artisan('operations:make AwesomeOperation')
             ->assertSuccessful()
-            ->expectsOutputToContain('One-time operation [2015_10_21_072800_awesome_operation] created successfully.');
+            ->expectsOutputToContain(sprintf('One-time operation [%s] created successfully.', $this->fileRealPath($filepath)));
 
         // file was created, but no operation entry yet
         $this->assertFileExists($filepath);
@@ -86,7 +86,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         // create operation file
         $this->artisan('operations:make AwesomeOperation')
             ->assertSuccessful()
-            ->expectsOutputToContain('One-time operation [2015_10_21_072800_awesome_operation] created successfully.');
+            ->expectsOutputToContain(sprintf('One-time operation [%s] created successfully.', $this->fileRealPath($filepath)));
 
         // file was created, but no operation entry yet
         $this->assertFileExists($filepath);
@@ -431,6 +431,11 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
     protected function filepath(string $filename): string
     {
         return base_path(config('one-time-operations.directory')).DIRECTORY_SEPARATOR.$filename;
+    }
+
+    protected function fileRealPath(string $filepath): string
+    {
+        return realpath('.').DIRECTORY_SEPARATOR.Str::afterLast($filepath, '../');
     }
 
     protected function tearDown(): void

--- a/tests/Feature/OneTimeOperationCreatorTest.php
+++ b/tests/Feature/OneTimeOperationCreatorTest.php
@@ -22,6 +22,7 @@ class OneTimeOperationCreatorTest extends OneTimeOperationCase
         $this->assertInstanceOf(OneTimeOperationFile::class, $operationFile);
         $this->assertInstanceOf(OneTimeOperation::class, $operationFile->getClassObject());
         $this->assertEquals('2015_10_21_072800_test_operation', $operationFile->getOperationName());
+        $this->assertStringContainsString('tests/files/2015_10_21_072800_test_operation.php', $operationFile->getOperationFilePath());
 
         File::delete($filepath);
     }


### PR DESCRIPTION
Right now the output of newly created operations file is:

```shell
php artisan operations:make Testing
>    INFO  One-time operation [2023_05_05_103905_testing] created successfully.
```

There is one drawback of this format, you can't _cmd+click_ on the operation name in terminal so that the filename would be opened in IDE.

Laravel has already changed that for migrations, and they return the full path to the filename, so it is possible to _cmd+click_ on it to be opened. An example:
```shell
php artisan make:migration testing
>   INFO  Migration [database/migrations/2023_05_05_104143_testing.php] created successfully.
```

So in this PR I try to replicate the same format, so we can open the newly created operations file. Each saved second counts 😄 

**The new output would be:**

```shell
php artisan operations:make Testing
>   INFO  One-time operation [operations/2023_05_05_104056_testing.php] created successfully.
```
<img width="749" alt="image" src="https://user-images.githubusercontent.com/12799259/236444240-fb2ffb03-263f-4844-8de3-6ffa56d4b46e.png">
