### PR TITLE
Specifies queues only when it's needed

### DIFF
--- a/src/Commands/OneTimeOperationsProcessCommand.php
+++ b/src/Commands/OneTimeOperationsProcessCommand.php
@@ -171,7 +171,7 @@ class OneTimeOperationsProcessCommand extends OneTimeOperationsCommand implement
             return;
         }
 
-        dispatchAsync($operation);
+        dispatch_sync($operation);
     }
 
     protected function testModeEnabled(): bool

--- a/src/Commands/OneTimeOperationsProcessCommand.php
+++ b/src/Commands/OneTimeOperationsProcessCommand.php
@@ -160,13 +160,18 @@ class OneTimeOperationsProcessCommand extends OneTimeOperationsCommand implement
 
     protected function dispatchOperationJob(OneTimeOperationFile $operationFile)
     {
-        if ($this->isAsyncMode($operationFile)) {
-            OneTimeOperationProcessJob::dispatch($operationFile->getOperationName())->onQueue($this->getQueue($operationFile));
+        $operation = new OneTimeOperationProcessJob($operationFile->getOperationName());
 
+        if ($this->isAsyncMode($operationFile)) {
+            if($queue = $this->getQueue($operationFile)){
+                $operation->onQueue($queue);
+            }
+
+            dispatch($operation);
             return;
         }
 
-        OneTimeOperationProcessJob::dispatchSync($operationFile->getOperationName());
+        dispatchAsync($operation);
     }
 
     protected function testModeEnabled(): bool


### PR DESCRIPTION
When deploying a `vapor` application, for example, it automatically fills in a default `queue`. Therefore, it will throw out these exceptions: 

```
Error executing "SendMessage" on "https://sqs.us-east-1.amazonaws.com/45610  
  2420676/default"; AWS HTTP error: Client error: `POST https://sqs.us-east-1/  
  .amazonaws.com/..../default` resulted in a `400 Bad Request` respon  
  se:                                                                          
  <?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2  
  012-11-05/"><Error><Type>Sender</Type><Code>A (truncated...)                 
   AWS.SimpleQueueService.NonExistentQueue (client): The specified queue does  
   not exist for this wsdl version. - <?xml version="1.0"?><ErrorResponse xml  
  ns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><  
  Code>AWS.SimpleQueueService.NonExistentQueue</Code><Message>The specified q  
  ueue does not exist for this wsdl version.</Message><Detail/></Error><Reque  
  stId>02a150eb-ca8f-5[486](#step:20:487)-8922-0d277ed8f750</RequestId></ErrorResponse>
```

This will happen because by default, the `OneTimeOperationsProcessCommand` will always specify a default queue. 

-----

This PR aims to fix that, by only calling `onQueue` if it has been defined and not null. 
It also reduces code duplication (just a line). 

----- 

Those who have this problem (in case this PR is not approved). You will need to override the `getQueue` method on your commands with the following:

```
    public function getQueue(): string
    {
        return config('queue.connections.sqs.queue');
    }
```

