### PR TITLE
[Enhancement] - Rename operations:make to make:operations for Better Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Now you're all set!
 ### Create operation files
 Create new operation file:
 ```shell
-php artisan operations:make <operation_name>
+php artisan make:operations <operation_name>
 ```
 Create file without any attributes:
 ```shell
-php artisan operations:make <operation_name> -e|--essential
+php artisan make:operations <operation_name> -e|--essential
 ```
 
 ### Process operations
@@ -168,7 +168,7 @@ Make changes as you like.
 To create a new operation file execute the following command:
 
 ```shell
-php artisan operations:make AwesomeOperation
+php artisan make:operations AwesomeOperation
 ```
 
 This will create a file like `operations/XXXX_XX_XX_XXXXXX_awesome_operation.php` with the following content.
@@ -231,8 +231,8 @@ _(this is only recommended for small operations, since the processing of these o
 If you don't need all the available attributes for your operation, you can create a *cleaner* operation file with the `--essential` or `-e` option: 
 
 ```shell
-php artisan operations:make AwesomeOperation --essential
-php artisan operations:make AwesomeOperation -e
+php artisan make:operations AwesomeOperation --essential
+php artisan make:operations AwesomeOperation -e
 ```
 
 ### Custom operation file

--- a/src/Commands/OneTimeOperationsMakeCommand.php
+++ b/src/Commands/OneTimeOperationsMakeCommand.php
@@ -7,7 +7,7 @@ use TimoKoerber\LaravelOneTimeOperations\OneTimeOperationCreator;
 
 class OneTimeOperationsMakeCommand extends OneTimeOperationsCommand
 {
-    protected $signature = 'operations:make
+    protected $signature = 'make:operations
                             {name : The name of the one-time operation}
                             {--e|essential : Create file without any attributes}';
 

--- a/tests/Feature/OneTimeOperationCommandTest.php
+++ b/tests/Feature/OneTimeOperationCommandTest.php
@@ -19,7 +19,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         File::delete($filepath);
 
         // create operation file
-        $this->artisan('operations:make AwesomeOperation')
+        $this->artisan('make:operations AwesomeOperation')
             ->assertSuccessful()
             ->expectsOutputToContain('One-time operation [2015_10_21_072800_awesome_operation] created successfully.');
 
@@ -40,7 +40,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         File::delete($filepath);
 
         // create operation file with essential flag
-        $this->artisan('operations:make AwesomeOperation --essential')->assertSuccessful();
+        $this->artisan('make:operations AwesomeOperation --essential')->assertSuccessful();
 
         $fileContent = File::get($filepath);
 
@@ -59,7 +59,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         File::delete($filepath);
 
         // create operation file with shortcut for essential flag
-        $this->artisan('operations:make AwesomeOperation -e')->assertSuccessful();
+        $this->artisan('make:operations AwesomeOperation -e')->assertSuccessful();
 
         $fileContent = File::get($filepath);
 
@@ -84,7 +84,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         Queue::assertNothingPushed();
 
         // create operation file
-        $this->artisan('operations:make AwesomeOperation')
+        $this->artisan('make:operations AwesomeOperation')
             ->assertSuccessful()
             ->expectsOutputToContain('One-time operation [2015_10_21_072800_awesome_operation] created successfully.');
 
@@ -156,7 +156,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         Queue::assertNothingPushed();
 
         // create operation
-        $this->artisan('operations:make FooBarOperation')->assertSuccessful();
+        $this->artisan('make:operations FooBarOperation')->assertSuccessful();
 
         // Process - error is thrown because both flags are used
         $this->artisan('operations:process --sync --async')
@@ -183,7 +183,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         Queue::assertNothingPushed();
 
         // create file
-        $this->artisan('operations:make FooBarOperation')->assertSuccessful();
+        $this->artisan('make:operations FooBarOperation')->assertSuccessful();
 
         // edit file so it will be executed synchronously
         $this->editFile('2015_10_21_072800_foo_bar_operation.php', '$async = true;', '$async = false;');
@@ -236,7 +236,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         Queue::assertNothingPushed();
 
         // create file
-        $this->artisan('operations:make FooBarOperation')->assertSuccessful();
+        $this->artisan('make:operations FooBarOperation')->assertSuccessful();
 
         // edit file so it will use different queue
         $this->editFile('2015_10_21_072800_foo_bar_operation.php', '$queue = \'default\';', '$queue = \'narfpuit\';');
@@ -270,7 +270,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         $this->assertEquals(0, Operation::count());
 
         // create file
-        $this->artisan('operations:make FooBarOperation')->assertSuccessful();
+        $this->artisan('make:operations FooBarOperation')->assertSuccessful();
 
         // process with test flag
         $this->artisan('operations:process --test')
@@ -287,9 +287,9 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
     public function test_processing_with_tags()
     {
         // create files
-        $this->artisan('operations:make FooBarOperation')->assertSuccessful();
-        $this->artisan('operations:make NarfPuitOperation')->assertSuccessful();
-        $this->artisan('operations:make NullTagOperation')->assertSuccessful();
+        $this->artisan('make:operations FooBarOperation')->assertSuccessful();
+        $this->artisan('make:operations NarfPuitOperation')->assertSuccessful();
+        $this->artisan('make:operations NullTagOperation')->assertSuccessful();
 
         // edit files so they will use tags
         $this->editFile('2015_10_21_072800_foo_bar_operation.php', '$tag = null;', '$tag = \'foobar\';');
@@ -366,7 +366,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
             ->expectsOutputToContain('No operations found.');
 
         // create operations
-        $this->artisan('operations:make FooBarOperation')->assertSuccessful();
+        $this->artisan('make:operations FooBarOperation')->assertSuccessful();
 
         // no files found
         $this->artisan('operations:show')
@@ -378,7 +378,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
             ->expectsOutputToContain('2015_10_21_072800_foo_bar_operation'); // PROCESSED
 
         // create operations
-        $this->artisan('operations:make AwesomeOperation')->assertSuccessful();
+        $this->artisan('make:operations AwesomeOperation')->assertSuccessful();
 
         // new pending operation added
         $this->artisan('operations:show')
@@ -388,7 +388,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         $this->artisan('operations:process')->assertSuccessful();
 
         // create operations
-        $this->artisan('operations:make SuperiorOperation')->assertSuccessful();
+        $this->artisan('make:operations SuperiorOperation')->assertSuccessful();
 
         // seconds operation was processed, third operation was added
         $this->artisan('operations:show')


### PR DESCRIPTION
Rename the operations:make command to make:operations to follow the standard Laravel command format.