### PR TITLE
Manage specific queue connection in configuration

### DIFF
--- a/config/one-time-operations.php
+++ b/config/one-time-operations.php
@@ -11,4 +11,8 @@ return [
     // Database Connection Name - Change the model connection, support for Multitenancy
     // Only change when you want to deviate from your system default repository
     'connection' => null,
+
+    // Queue Connection Name
+    // Only change when you want to use a specific queue connection different from default
+    'queue_connection' => env('ONE_TIME_OPERATIONS_QUEUE_CONNECTION', env('QUEUE_CONNECTION', 'sync')),
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,5 +16,6 @@
     </coverage>
     <php>
         <env name="DB_CONNECTION" value="testing"/>
+        <env name="QUEUE_CONNECTION" value="default"/>
     </php>
 </phpunit>

--- a/src/Commands/OneTimeOperationsProcessCommand.php
+++ b/src/Commands/OneTimeOperationsProcessCommand.php
@@ -161,7 +161,9 @@ class OneTimeOperationsProcessCommand extends OneTimeOperationsCommand implement
     protected function dispatchOperationJob(OneTimeOperationFile $operationFile)
     {
         if ($this->isAsyncMode($operationFile)) {
-            OneTimeOperationProcessJob::dispatch($operationFile->getOperationName())->onQueue($this->getQueue($operationFile));
+            OneTimeOperationProcessJob::dispatch($operationFile->getOperationName())
+                                      ->onQueue($this->getQueue($operationFile))
+                                      ->onConnection(OneTimeOperationManager::getConnectionName());
 
             return;
         }

--- a/src/OneTimeOperationManager.php
+++ b/src/OneTimeOperationManager.php
@@ -108,6 +108,11 @@ class OneTimeOperationManager
         return Config::get('one-time-operations.directory');
     }
 
+    public static function getConnectionName(): string
+    {
+        return Config::get('one-time-operations.queue_connection');
+    }
+
     public static function getDirectoryPath(): string
     {
         return App::basePath(Str::of(self::getDirectoryName())->rtrim('/')).DIRECTORY_SEPARATOR;

--- a/tests/Feature/OneTimeOperationCase.php
+++ b/tests/Feature/OneTimeOperationCase.php
@@ -3,6 +3,7 @@
 namespace TimoKoerber\LaravelOneTimeOperations\Tests\Feature;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
@@ -24,6 +25,9 @@ abstract class OneTimeOperationCase extends TestCase
 
         Queue::fake();
         Carbon::setTestNow(self::TEST_DATETIME);
+
+        Config::set('queue.default', 'default');
+
     }
 
     protected function getPackageProviders($app): array

--- a/tests/Feature/OneTimeOperationCommandTest.php
+++ b/tests/Feature/OneTimeOperationCommandTest.php
@@ -3,6 +3,7 @@
 namespace TimoKoerber\LaravelOneTimeOperations\Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
@@ -113,7 +114,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         // operation was exectued - database entry and job was created
         $this->assertEquals(1, Operation::count());
         Queue::assertPushed(OneTimeOperationProcessJob::class, function (OneTimeOperationProcessJob $job) {
-            return $job->connection === null; // async
+            return $job->connection === Config::get('one-time-operations.queue_connection'); // async
         });
 
         // entry was created successfully
@@ -221,7 +222,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         // Job was executed asynchronously
         Queue::assertPushed(OneTimeOperationProcessJob::class, function (OneTimeOperationProcessJob $job) {
             return $job->operationName === '2015_10_21_072800_foo_bar_operation'
-                && $job->connection === null // async
+                && $job->connection === Config::get('one-time-operations.queue_connection') // async
                 && $job->queue === 'default'; // default queue
         });
 
@@ -237,7 +238,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         // Job was executed asynchronously on queue "foobar"
         Queue::assertPushed(OneTimeOperationProcessJob::class, function (OneTimeOperationProcessJob $job) {
             return $job->operationName === '2015_10_21_072800_foo_bar_operation'
-                && $job->connection === null // async
+                && $job->connection === Config::get('one-time-operations.queue_connection') // async
                 && $job->queue === 'foobar'; // default queue
         });
     }
@@ -258,7 +259,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         // Job was executed synchronously
         Queue::assertPushed(OneTimeOperationProcessJob::class, function (OneTimeOperationProcessJob $job) {
             return $job->operationName === '2015_10_21_072800_foo_bar_operation'
-                && $job->connection === null // async
+                && $job->connection === Config::get('one-time-operations.queue_connection') // async
                 && $job->queue === 'narfpuit'; // queue narfpuit
         });
 
@@ -270,7 +271,7 @@ class OneTimeOperationCommandTest extends OneTimeOperationCase
         // Job was executed asynchronously on queue "foobar"
         Queue::assertPushed(OneTimeOperationProcessJob::class, function (OneTimeOperationProcessJob $job) {
             return $job->operationName === '2015_10_21_072800_foo_bar_operation'
-                && $job->connection === null // async
+                && $job->connection === Config::get('one-time-operations.queue_connection') // async
                 && $job->queue === 'foobar'; // queue foobar
         });
     }


### PR DESCRIPTION
### What kind of change does this PR introduce?
Feature

### What is the new behavior?
It adds the possibility to specify a custom queue connection, other then the default one, for asyc operations processing

### Does this PR introduce a breaking change?
No, since if the configuration key is not available in the published config, it uses the default queue connection

### Other information:
N/A
