### PR TITLE
Change OperationsLineElement::$processedAt type to CarbonInterface

### DIFF
--- a/src/Commands/Utils/OperationsLineElement.php
+++ b/src/Commands/Utils/OperationsLineElement.php
@@ -2,8 +2,8 @@
 
 namespace TimoKoerber\LaravelOneTimeOperations\Commands\Utils;
 
+use Carbon\CarbonInterface;
 use Illuminate\Console\View\Components\Factory;
-use Illuminate\Support\Carbon;
 use TimoKoerber\LaravelOneTimeOperations\Commands\OneTimeOperationsCommand;
 
 class OperationsLineElement
@@ -13,12 +13,12 @@ class OperationsLineElement
     public function __construct(
         public string $name,
         public string $status,
-        public ?Carbon $processedAt = null,
+        public ?CarbonInterface $processedAt = null,
         public ?string $tag = null,
     ) {
     }
 
-    public static function make(string $name, string $status, Carbon $processedAt = null, string $tag = null): self
+    public static function make(string $name, string $status, CarbonInterface $processedAt = null, string $tag = null): self
     {
         return new self($name, $status, $processedAt, $tag);
     }


### PR DESCRIPTION
This pull request refactors the `OperationsLineElement` class to improve type safety and compatibility by replacing the use of the concrete `Carbon` class with the more generic `CarbonInterface` for the `processedAt` property and related methods.

Type improvements:

* Changed the type of the `processedAt` property and the corresponding constructor and `make` method parameters from `Carbon` to `CarbonInterface` in `OperationsLineElement`, allowing for greater flexibility and better adherence to interface-based programming. [[1]](diffhunk://#diff-ba6efab1a3e6e31fc93e72d03418601e7dfae02e6cd587dcc5591196547895c8R5-L6) [[2]](diffhunk://#diff-ba6efab1a3e6e31fc93e72d03418601e7dfae02e6cd587dcc5591196547895c8L16-R21)

Fixes: #46 

Replaces: #47 